### PR TITLE
ignore case when matching

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -245,7 +245,7 @@ function getCompletions(token, keywords, options = {startAtStart: false}) {
 		return keywords.map(e => {
 			return {...e, ...{text: token + e.text}};
 		});
-	const regex = new RegExp(`${options.startAtStart ? '^' : ''}${token}`);
+	const regex = new RegExp(`${options.startAtStart ? '^' : ''}${token}`, 'i');
 	return keywords.filter(e => regex.exec(e.text));
 }
 


### PR DESCRIPTION
This switched the `Regexp` object to use the `'i'` flag.

Before: typing `@a` would not include `Actor` as the object type (and similarly, individual actors/etc needed case sensitivity).

Note: I did this when I didn't have time to test it. I'll attempt to load it locally soon to verify it does what I want.